### PR TITLE
Fix UnicodeDecodeError and check return code

### DIFF
--- a/wzhifuSDK.py
+++ b/wzhifuSDK.py
@@ -48,6 +48,10 @@ try:
 except ImportError:
     pycurl = None
 
+import sys 
+reload(sys)
+sys.setdefaultencoding('utf-8')
+
 
 class WxPayConf_pub(object):
     """配置账号信息"""
@@ -367,8 +371,11 @@ class UnifiedOrder_pub(Wxpay_client_pub):
         """获取prepay_id"""
         self.postXml()
         self.result = self.xmlToArray(self.response)
-        prepay_id = self.result["prepay_id"]
-        return prepay_id
+        if "return_code" in self.result and self.result["return_code"].upper() == "SUCCESS":
+            prepay_id = self.result["prepay_id"]
+            return prepay_id
+        else: 
+            return None
 
 
 class OrderQuery_pub(Wxpay_client_pub):
@@ -606,8 +613,6 @@ def test():
     assert c.get("http://www.baidu.com")[:15] == "<!DOCTYPE html>"
     c2 = HttpClient()
     assert id(c) == id(c2)
-
-
 
 if __name__ == "__main__":
     test()


### PR DESCRIPTION
在获取prepayId的时候，如果参数中含中文会出现UnicodeDecodeError错误，原因是Python 2.x中，字符串的默认编码是ascii码，format()函数碰到Unicode会出错。另外，getPrepayId最好检查下return code，否则会导致后面的程序出错。
